### PR TITLE
[Feat]: 월별 통계, 연령대별 지출 비교 페이지 데이터 조회 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,45 +6,49 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import MonthlyStatics from './src/screens/MonthlyStatics';
 import AgeCompare from './src/screens/AgeCompare';
 import MenuBar from './src/screens/MenuBar';
+import { MonthlyStaticsProvider } from './src/context/MonthlyStaticsContext'; // Context 추가
 
 const Stack = createNativeStackNavigator();
 
 const App = () => {
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        {/* 월별 통계 페이지 */}
-        <Stack.Screen
-          name="MonthlyStatics"
-          component={MonthlyStatics}
-          options={{
-            headerShown: false,
-            animation: 'slide_from_right', // 오른쪽에서 왼쪽으로 슬라이드
+    <MonthlyStaticsProvider> {/* Context Provider로 감싸기 */}
+      <NavigationContainer>
+        <Stack.Navigator
+          screenOptions={{
+            headerShown: false, // 기본적으로 헤더를 숨김
           }}
-        />
+        >
+          {/* 월별 통계 페이지 */}
+          <Stack.Screen
+            name="MonthlyStatics"
+            component={MonthlyStatics}
+            options={{
+              animation: 'slide_from_right', // 오른쪽에서 왼쪽으로 슬라이드
+            }}
+          />
 
-        {/* 연령대별 지출 비교 페이지 */}
-        <Stack.Screen
-          name="AgeCompare"
-          component={AgeCompare}
-          options={{
-            headerShown: false,
-            animation: 'slide_from_right', // 오른쪽에서 왼쪽으로 슬라이드
-          }}
-        />
+          {/* 연령대별 지출 비교 페이지 */}
+          <Stack.Screen
+            name="AgeCompare"
+            component={AgeCompare}
+            options={{
+              animation: 'slide_from_right', // 오른쪽에서 왼쪽으로 슬라이드
+            }}
+          />
 
-        {/* 메뉴 페이지 */}
-        <Stack.Screen
-          name="Menu"
-          component={MenuBar}
-          options={{
-            presentation: 'transparentModal', // 모달로 설정
-            animation: 'slide_from_left', // 왼쪽에서 오른쪽으로 슬라이드
-            headerShown: false, // 헤더 숨김
-          }}
-        />
-      </Stack.Navigator>
-    </NavigationContainer>
+          {/* 메뉴 페이지 */}
+          <Stack.Screen
+            name="Menu"
+            component={MenuBar}
+            options={{
+              presentation: 'transparentModal', // 모달로 설정
+              animation: 'slide_from_left', // 왼쪽에서 오른쪽으로 슬라이드
+            }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </MonthlyStaticsProvider>
   );
 };
 

--- a/App.js
+++ b/App.js
@@ -45,7 +45,9 @@ const App = () => {
               presentation: 'transparentModal', // 모달로 설정
               animation: 'slide_from_left', // 왼쪽에서 오른쪽으로 슬라이드
             }}
+            initialParams={{ userName: '홍길동', percent: 25 }} // 기본 매개변수 전달
           />
+
         </Stack.Navigator>
       </NavigationContainer>
     </MonthlyStaticsProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@react-native-firebase/analytics": "^21.4.0",
         "@react-native-firebase/app": "^21.4.0",
         "@react-native-firebase/auth": "^21.4.0",
+        "@react-native-firebase/firestore": "^21.4.0",
         "@react-native-picker/picker": "^2.9.0",
         "@react-navigation/drawer": "^7.0.4",
         "@react-navigation/native": "^7.0.0",
@@ -4081,6 +4082,15 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-firebase/firestore": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/firestore/-/firestore-21.4.0.tgz",
+      "integrity": "sha512-9g2HIS3dBXAP7D4GECTDllLxkTUhlW5rnjoneHIRqbtlR+Hmn1H+yDnkAswhIdyZPzyBUsvTawbRtsNKQC/KIg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@react-native-firebase/app": "21.4.0"
       }
     },
     "node_modules/@react-native-picker/picker": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-native-firebase/analytics": "^21.4.0",
     "@react-native-firebase/app": "^21.4.0",
     "@react-native-firebase/auth": "^21.4.0",
+    "@react-native-firebase/firestore": "^21.4.0",
     "@react-native-picker/picker": "^2.9.0",
     "@react-navigation/drawer": "^7.0.4",
     "@react-navigation/native": "^7.0.0",

--- a/src/components/common/AmountDetail.js
+++ b/src/components/common/AmountDetail.js
@@ -7,38 +7,26 @@ import IncomeIcon from '../../asset/income/IncomeColored.svg';
 import ExpenseBrownIcon from '../../asset/expense/ExpenseBrown.svg';
 import ExpenseIcon from '../../asset/expense/ExpenseColored.svg';
 import CalendarSelector from '../monthlyStatics/CalendarSelector';
-import IncomeExpenseList from '../monthlyStatics/IncomeExpenseList';
+import IncomeOutcomeList from '../monthlyStatics/IncomeOutcomeList';
 import styles from '../../styles/common/amountDetailStyles';
 
 const AmountDetail = ({
   income,
   incomeChange,
-  expense,
-  expenseChange,
+  outcome,
+  outcomeChange,
   isAgeCompare,
   incomeLabel = '수입',
-  expenseLabel = '지출',
+  outcomeLabel = '지출',
+  incomeList,
+  outcomeList,
 }) => {
   const [isCalendarVisible, setCalendarVisibility] = useState(false);
   const [selectedType, setSelectedType] = useState(null);
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
   const [filteredIncomeList, setFilteredIncomeList] = useState([]);
-  const [filteredExpenseList, setFilteredExpenseList] = useState([]);
-
-  // 예시 수입 및 지출 데이터
-  const incomeList = [
-    { id: 1, title: '초밥', amount: 1600000, date: '2024-11-24', time: '15:00', category: '식비' },
-    { id: 2, title: '무신사', amount: 500000, date: '2024-10-15', time: '10:30', category: '쇼핑' },
-    { id: 3, title: '투썸플레이스', amount: 500000, date: '2024-09-04', time: '09:15', category: '카페' },
-    { id: 4, title: '맥도날드', amount: 5000, date: '2024-11-29', time: '17:00', category: '식비' },
-  ];
-
-  const expenseList = [
-    { id: 1, title: 'CU', amount: 100000, date: '2024-08-20', time: '12:00', category: '편의점' },
-    { id: 2, title: '미정', amount: 500000, date: '2024-07-01', time: '08:45', category: '이체' },
-    { id: 3, title: '렌트', amount: 20000, date: '2024-06-01', time: '18:20', category: '기타' },
-  ];
+  const [filteredOutcomeList, setFilteredOutcomeList] = useState([]);
 
   // 연도 또는 월이 변경될 때마다 데이터를 필터링
   useEffect(() => {
@@ -49,14 +37,14 @@ const AmountDetail = ({
           new Date(item.date).getMonth() + 1 === selectedMonth
       );
 
-      const filteredExpense = expenseList.filter(
+      const filteredOutcome = outcomeList.filter(
         (item) =>
           new Date(item.date).getFullYear() === selectedYear &&
           new Date(item.date).getMonth() + 1 === selectedMonth
       );
 
       setFilteredIncomeList(filteredIncome);
-      setFilteredExpenseList(filteredExpense);
+      setFilteredOutcomeList(filteredOutcome);
     }
   }, [selectedYear, selectedMonth, isCalendarVisible]);
 
@@ -70,7 +58,7 @@ const AmountDetail = ({
       {/* 수입 및 지출 비교 섹션 */}
       <View style={styles.compareContainer}>
         <TouchableOpacity
-          style={[styles.compareItem, selectedType === 'expense' && styles.blur]}
+          style={[styles.compareItem, selectedType === 'outcome' && styles.blur]}
           onPress={!isAgeCompare ? () => showCalendar('income') : null} // isAgeCompare가 true이면 비활성화
           disabled={isAgeCompare} // isAgeCompare가 true이면 비활성화
         >
@@ -91,16 +79,16 @@ const AmountDetail = ({
 
         <TouchableOpacity
           style={[styles.compareItem, selectedType === 'income' && styles.blur]}
-          onPress={!isAgeCompare ? () => showCalendar('expense') : null} // isAgeCompare가 true이면 비활성화
+          onPress={!isAgeCompare ? () => showCalendar('outcome') : null} // isAgeCompare가 true이면 비활성화
           disabled={isAgeCompare} // isAgeCompare가 true이면 비활성화
         >
           <ExpenseIcon width={24} height={24} style={styles.icon} />
-          <Text style={styles.compareLabel}>{expenseLabel}</Text>
-          <Text style={styles.expenseAmount}>{expense.toLocaleString()}</Text>
+          <Text style={styles.compareLabel}>{outcomeLabel}</Text>
+          <Text style={styles.expenseAmount}>{outcome.toLocaleString()}</Text>
           {!isAgeCompare && (
             <>
               <Text style={styles.compareChange}>지난 달 대비</Text>
-              <Text style={styles.compareChange}>-{expenseChange?.toLocaleString()}</Text>
+              <Text style={styles.compareChange}>-{outcomeChange?.toLocaleString()}</Text>
             </>
           )}
         </TouchableOpacity>
@@ -118,9 +106,9 @@ const AmountDetail = ({
 
       {/* 선택한 월의 수입 또는 지출 목록 */}
       {isCalendarVisible && selectedType && (
-        <IncomeExpenseList
+        <IncomeOutcomeList
           incomeList={selectedType === 'income' ? filteredIncomeList : []}
-          expenseList={selectedType === 'expense' ? filteredExpenseList : []}
+          outcomeList={selectedType === 'outcome' ? filteredOutcomeList : []}
           selectedType={selectedType}
           selectedYear={selectedYear}
           selectedMonth={selectedMonth}

--- a/src/components/monthlyStatics/AmountSummary.js
+++ b/src/components/monthlyStatics/AmountSummary.js
@@ -1,35 +1,36 @@
-// src/components/common/AmountSummary.js
-// 월별 통계 페이지 - 총 잔액, 총 진출
+// src/components/monthlyStatics/AmmountSummary.js
+// 월별 통게 페이지 - 총 잔액( (설정 예산) – (총 지출) ), 총 지출
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
-import IncomeIcon from '../../asset/income/Income.svg';
+import IncomeIcon from '../../asset/income/Income.svg'; // 수입 아이콘 가져오기
 import ExpenseIcon from '../../asset/expense/Expense.svg'; // 지출 아이콘 가져오기
-import styles from '../../styles/monthlyStatics/amountSummaryStyles';
+import firestore from '@react-native-firebase/firestore'; // Firestore 연동
+import styles from '../../styles/monthlyStatics/amountSummaryStyles'; // 스타일 가져오기
 
-const AmountSummary = ({ label, amount = 0, isIncome }) => {
+const AmountSummary = ({ label, isBudget, budget, outcome }) => {
   return (
     <View style={styles.container}>
-      {/* 라벨 및 아이콘 */}
+      {/* 라벨과 아이콘 표시 */}
       <View style={styles.labelContainer}>
-        {isIncome ? ( // 수입 아이콘
+        {isBudget ? ( // `isBudget`이 true이면 수입 아이콘 표시
           <IncomeIcon width={16} height={16} style={styles.icon} />
-        ) : ( // 지출 아이콘
+        ) : ( // `isBudget`이 false이면 지출 아이콘 표시
           <ExpenseIcon width={16} height={16} style={styles.icon} />
         )}
-        <Text style={styles.label}>{label}</Text>
+        <Text style={styles.label}>{label}</Text> {/* 라벨 표시 */}
       </View>
 
       {/* 금액 표시 */}
       <Text
         style={[
           styles.amount,
-          isIncome ? styles.income : styles.expand, // 스타일 적용
+          isBudget ? styles.income : styles.expand, // 수입/지출에 따라 스타일 적용
         ]}
       >
-        {isIncome
-          ? `${amount.toLocaleString()} 원`
-          : `-${amount.toLocaleString()} 원`}
+        {isBudget
+          ? `${(budget-outcome).toLocaleString()} 원`
+          : `-${outcome.toLocaleString()} 원`}
       </Text>
     </View>
   );

--- a/src/components/monthlyStatics/BudgetIndicator.js
+++ b/src/components/monthlyStatics/BudgetIndicator.js
@@ -1,17 +1,33 @@
 // src/components/monthlyStatics/BudgetIndicator.js
 // 월별 통게 페이지 - 예산 사용량 요약
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import BudgetProgressBar from './BudgetProgressBar';
 import BudgetDescription from './BudgetDescription';
 import styles from '../../styles/monthlyStatics/budgetIndicatorStyles';
 
-const BudgetIndicator = ({ percentage, totalAmount }) => (
-  <View style={styles.budgetContainer}>
-    <BudgetProgressBar percentage={percentage} totalAmount={totalAmount} />
-    <BudgetDescription percentage={percentage} />
-  </View>
-);
+const BudgetIndicator = ({ budget, outcome }) => {
+  const [percentage, setPercentage] = useState(0); // 예산 대비 지출 퍼센트
+
+  // 퍼센트 계산 함수
+  const getOutComePercent = (budget, outcome) => {
+    if (budget === 0) return 0; // 예산이 0인 경우 퍼센트를 0으로 설정
+    return Math.min((outcome / budget) * 100, 100); // 최대 퍼센트는 100%로 제한
+  };
+
+  // 퍼센트 계산 및 상태 업데이트
+  useEffect(() => {
+    const percent = getOutComePercent(budget, outcome);
+    setPercentage(percent);
+  }, [budget, outcome]); // budget이나 outcome이 변경될 때마다 실행
+
+  return (
+    <View style={styles.budgetContainer}>
+      <BudgetProgressBar percentage={percentage} outcome={outcome} />
+      <BudgetDescription percentage={percentage} />
+    </View>
+  );
+};
 
 export default BudgetIndicator;

--- a/src/components/monthlyStatics/BudgetProgressBar.js
+++ b/src/components/monthlyStatics/BudgetProgressBar.js
@@ -6,7 +6,7 @@ import { View, Text } from 'react-native';
 import ProgressBar from 'react-native-progress/Bar';
 import styles from '../../styles/monthlyStatics/budgetProgressBarStyles';
 
-const BudgetProgressBar = ({ percentage, totalAmount }) => (
+const BudgetProgressBar = ({ percentage, outcome }) => (
   <View style={styles.progressBarContainer}>
     <ProgressBar
       progress={percentage / 100}
@@ -19,7 +19,7 @@ const BudgetProgressBar = ({ percentage, totalAmount }) => (
       style={styles.progressBar}
     />
     <Text style={styles.percentageText}>{percentage}%</Text>
-    <Text style={styles.totalAmountText}>{totalAmount.toLocaleString()} 원</Text>
+    <Text style={styles.totalAmountText}>{outcome.toLocaleString()} 원</Text>
   </View>
 );
 

--- a/src/components/monthlyStatics/FirebaseTest.js
+++ b/src/components/monthlyStatics/FirebaseTest.js
@@ -1,0 +1,123 @@
+import firestore from '@react-native-firebase/firestore';
+
+const FirebaseTest = () => {
+    // 1. 유저 데이터를 추가
+    const addUserData = async (uid, userData) => {
+      try {
+        await firestore().collection('users').doc(uid).set({
+          name: userData.name,
+          email: userData.email,
+          phoneNumber: userData.phoneNumber,
+          birth: userData.birth,
+          password: userData.password,
+        });
+
+        console.log('User data added successfully!');
+      } catch (error) {
+        console.error('Error adding user data:', error);
+      }
+    };
+
+    // 2. 예산 데이터 추가
+    const addBudgetData = async (uid, budgetData) => {
+      try {
+        const budgetRef = firestore()
+          .collection('users')
+          .doc(uid)
+          .collection('budget');
+        for (const { date, targetBudget } of budgetData) {
+          await budgetRef.doc(date).set({ targetBudget });
+        }
+        console.log('Budget data added successfully!');
+      } catch (error) {
+        console.error('Error adding budget data:', error);
+      }
+    };
+
+    // 3. 일일 수입/지출 데이터 추가
+    const addDailyTransactionData = async (uid, date, transactionType, transactionData) => {
+      try {
+        await firestore()
+          .collection('users')
+          .doc(uid)
+          .collection(date)
+          .doc(transactionType) // 'income' or 'outcome'
+          .set(transactionData);
+
+        console.log(${transactionType} data added successfully for ${date}!);
+      } catch (error) {
+        console.error(Error adding ${transactionType} data:, error);
+      }
+    };
+
+    // 4. 계층 데이터 추가 전체 함수
+    const addCompleteUserData = async () => {
+      const uid = '2'; // 유저 ID (문서 ID)
+      const userData = {
+        name: '미정',
+        email: '2271224@hansung.ac.kr',
+        phoneNumber: '010-1234-5678',
+        birth: '2004-01-08',
+        password: 'testpassword',
+      };
+
+      const budgetData = [
+        { date: '2024-11', targetBudget: 5000 },
+        { date: '2024-12', targetBudget: 6000 },
+      ];
+
+      const dailyTransactions = [
+        {
+          date: '2024-10-15',
+          outcome: {
+            money: 3000,
+            memo: 'gs25에서 과자 사먹음',
+            time: '08:00',
+            category: '편의점',
+          },
+        },
+        {
+          date: '2024-11-19',
+          income: {
+            money: 4000,
+            memo: '이체금',
+            time: '10:00',
+            category: '이체',
+          },
+          outcome: {
+            money: 2000,
+            memo: '메가커피에서 아이스 아메리카노 사먹음',
+            time: '10:00',
+            category: '식비',
+          },
+        },
+      ];
+
+      try {
+        // 유저 데이터 추가
+        await addUserData(uid, userData);
+
+        // 예산 데이터 추가
+        await addBudgetData(uid, budgetData);
+
+        // 수입/지출 데이터 추가
+        for (const { date, income, outcome } of dailyTransactions) {
+          if (income) {
+            await addDailyTransactionData(uid, date, 'income', income);
+          }
+          if (outcome) {
+            await addDailyTransactionData(uid, date, 'outcome', outcome);
+          }
+        }
+
+        console.log('유저 데이터 저장 완료');
+      } catch (error) {
+        console.error('Error adding complete user data:', error);
+      }
+    };
+
+    // 호출
+    addCompleteUserData();
+}
+
+export default FirebaseTest;

--- a/src/components/monthlyStatics/IncomeOutcomeList.js
+++ b/src/components/monthlyStatics/IncomeOutcomeList.js
@@ -11,7 +11,7 @@ import MoneyCategory from '../../asset/category/MoneyCategory.svg';
 import EtcCategory from '../../asset/category/EtcCategory.svg';
 import IncomeIcon from '../../asset/income/IncomeColored.svg';
 import ExpenseIcon from '../../asset/expense/ExpenseColored.svg';
-import styles from '../../styles/monthlyStatics/incomeExpenseListStyles';
+import styles from '../../styles/monthlyStatics/incomeOutcomeListStyles';
 
 const categoryIcons = {
   식비: FoodCategory,
@@ -22,15 +22,15 @@ const categoryIcons = {
   기타: EtcCategory,
 };
 
-const IncomeExpenseList = ({ incomeList, expenseList, selectedType, selectedYear, selectedMonth }) => {
+const IncomeOutcomeList = ({ incomeList, outcomeList, selectedType, selectedYear, selectedMonth }) => {
   const monthName = ["1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"][selectedMonth - 1];
   const isIncome = selectedType === 'income';
-  const dataList = isIncome ? incomeList : expenseList;
+  const dataList = isIncome ? incomeList : outcomeList;
   const listHeader = `${monthName} ${isIncome ? '수입' : '지출'}`;
   const HeaderIcon = isIncome ? IncomeIcon : ExpenseIcon;
 
    // 금액 합계를 계산
-   const totalAmount = dataList.reduce((acc, item) => acc + item.amount, 0);
+   const totalAmount = dataList.reduce((acc, item) => acc + item.money, 0);
 
    return (
        <View style={styles.container}>
@@ -63,11 +63,11 @@ const IncomeExpenseList = ({ incomeList, expenseList, selectedType, selectedYear
                      <CategoryIcon width={50} height={50} />
                    </View>
                    <View style={styles.listItemContent}>
-                     <Text style={styles.listItemTitle}>{item.title}</Text>
+                     <Text style={styles.listItemTitle}>{item.memo}</Text>
                      <Text style={styles.listItemDate}>{`${item.time} - ${new Date(item.date).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })}`}</Text>
                    </View>
                    <Text style={[styles.listItemAmount, isIncome ? styles.incomeAmount : styles.expenseAmount]}>
-                     {isIncome ? '+' : '-'}{item.amount.toLocaleString()}
+                     {isIncome ? '+' : '-'}{item.money.toLocaleString()}
                    </Text>
                  </View>
                );
@@ -78,4 +78,4 @@ const IncomeExpenseList = ({ incomeList, expenseList, selectedType, selectedYear
      );
    };
 
-   export default IncomeExpenseList;
+   export default IncomeOutcomeList;

--- a/src/context/MonthlyStaticsContext.js
+++ b/src/context/MonthlyStaticsContext.js
@@ -1,0 +1,41 @@
+// src/context/MonthlyStaticsContext.js
+// 월별 통계 데이터 전역 상태로 관리
+
+// Firebase에서 데이터를 처음 조회한 뒤, 전역 상태에 저장
+// 이후 월별 통계 페이지로 다시 돌아오면 전역 상태를 확인하여 데이터를 로드
+
+import React, { createContext, useState, useContext } from "react";
+
+// MonthlyStaticsContext 생성
+// 데이터를 전역적으로 공유할 수 있도록 컨텍스트를 생성
+const MonthlyStaticsContext = createContext();
+
+// 컨텍스트의 프로바이더 정의
+// 전역 상태를 제공할
+export const MonthlyStaticsProvider = ({ children }) => {
+
+  // 전역으로 관리될 상태 정의
+  // 데이터를 캐싱하기 위해 초기값으로 설정된 상태를 사용
+  const [cachedData, setCachedData] = useState({
+    budget: 0, // 예산
+    income: 0, // 현재 월 수입
+    outcome: 0, // 현재 월 지출
+    lastMonthIncome: 0, // 지난달 수입
+    lastMonthOutcome: 0, // 지난달 지출
+    chartData: [], // 차트에 표시될 월별 데이터
+    incomeList: [], // 수입 상세 리스트
+    outcomeList: [], // 지출 상세 리스트
+  });
+
+  // MonthlyStaticsContext.Provider를 통해 상태와 상태 업데이트 함수를 자식 컴포넌트에 제공
+  return (
+    <MonthlyStaticsContext.Provider value={{ cachedData, setCachedData }}>
+      {children}
+    </MonthlyStaticsContext.Provider>
+  );
+};
+
+// 컨텍스트를 쉽게 사용할 수 있도록 커스텀 훅 정의
+// 컨텍스트 값을 반환하며, 이를 통해 전역 상태에 접근하거나 업데이트할 수 있음
+// useContext 라는 Hook을 사용하여 Context에 넣은 값에 바로 접근
+export const useMonthlyStatics = () => useContext(MonthlyStaticsContext);

--- a/src/screens/AgeCompare.js
+++ b/src/screens/AgeCompare.js
@@ -9,14 +9,20 @@ import WeeklyChart from '../components/common/CustomChart';
 import AmountDetail from '../components/common/AmountDetail';
 import styles from '../styles/ageCompare/ageCompareStyles';
 import Header from '../components/common/Header';
+import firestore from '@react-native-firebase/firestore';
 
 const AgeCompare = () => {
+  const uid = "2"; // 테스트 uid
+
   const [selectedDate, setSelectedDate] = useState(null); // 선택된 날짜 초기값 null
+  const [year, setYear] = useState(0);
+  const [month, setMonth] = useState(0);
   const [age, setAge] = useState(''); // 입력된 나이
   const [isCalendarVisible, setCalendarVisible] = useState(false); // 캘린더 표시 여부
   const [isConfirmed, setIsConfirmed] = useState(false); // 데이터 확인 여부
   const [chartData, setChartData] = useState([]); // 차트 데이터
-  const [summaryData, setSummaryData] = useState({ myExpense: 0, peerExpense: 0 }); // 요약 데이터
+  const [myOutcome, setMyOutcome] = useState(0); // 내지출
+  const [peerOutcome, setPeerOutcome] = useState(0); // 또래지출
 
   // 나이 유효성 검사
   const validateAge = (input) => {
@@ -31,46 +37,126 @@ const AgeCompare = () => {
     return `${year}년 ${month}월`;
   };
 
-  // 차트 데이터 예시
-  const fetchChartData = () => [
-    { label: '1주', income: 12000, expense: 8000 },
-    { label: '2주', income: 4000, expense: 7000 },
-    { label: '3주', income: 8000, expense: 1000 },
-    { label: '4주', income: 10000, expense: 5000 },
-  ];
+  // 캘린더에서 날짜 선택 완료 시
+  const handleConfirmDate = (event, date) => {
+    if (date) {
+      setSelectedDate(date); // 선택된 날짜 저장
+      setYear(date.getFullYear()); // 연도 저장
+      setMonth(date.getMonth() + 1); // 월 저장
+    }
+    setCalendarVisible(false); // 캘린더 닫기
+  };
 
-  // 요약 데이터 예시
-  const fetchSummaryData = () => ({
-    myExpense: 230000,
-    peerExpense: 200000,
-  });
+  // 사용자가 설정한 연도, 월의 주차별 수입, 지출 차트 데이터 조회
+  const fetchChartData = async (uid) => {
+    try {
+      // Firestore 참조
+      const weeksRef = firestore()
+        .collection('WeekAmount')
+        .doc(uid)
+        .collection('Year')
+        .doc(year.toString())
+        .collection('Month')
+        .doc(month.toString())
+        .collection('Weeks');
+
+      // Firestore에서 문서 ID를 기준으로 주차 데이터 가져오기
+      const weekDocNumbers = ['1', '2', '3', '4']; // 주차 번호를 문자열로 명시
+      const weekPromises = weekDocNumbers.map((weekNumber) => weeksRef.doc(weekNumber).get());
+
+      const weekSnapshots = await Promise.all(weekPromises);
+
+      // 주차별 데이터를 매핑하면서 총 지출 (totalOutcome) 계산
+      let totalOutcome = 0;
+
+      const weekData = weekSnapshots.map((snapshot, index) => {
+        if (snapshot.exists) {
+          const { income = 0, outcome = 0 } = snapshot.data();
+          totalOutcome += outcome; // 총 지출 계산
+          return {
+            label: `${weekDocNumbers[index]}주`, // 주차 번호 사용
+            income,
+            expense: outcome,
+          };
+        }
+        return {
+          label: `${weekDocNumbers[index]}주`,
+          income: 0,
+          expense: 0,
+        };
+      });
+
+      // 차트 데이터 상태 업데이트
+      setChartData(weekData);
+      setMyOutcome(totalOutcome);
+
+      console.log('Fetched Chart Data:', weekData);
+
+      return weekData; // 최종 데이터 반환
+    } catch (error) {
+      console.error('Error fetching weekly chart data:', error);
+      return [];
+    }
+  };
+
+  // 또래 지출 조회
+  const fetchPeerOutcome = async (age) => {
+    try {
+      // age를 기준으로 또래 나이 그룹 계산
+      const peerAge = age < 10 ? 0 : parseInt(age.toString()[0] + '0', 10);
+
+      console.log('Peer Age Group:', peerAge);
+
+      // Firestore 참조
+      const peerOutcomeRef = firestore()
+        .collection('PeerOutcome')
+        .doc(peerAge.toString()) // 나이 그룹
+        .collection('peer')
+        .doc('outcome');
+
+      // Firestore 데이터 가져오기
+      const peerDoc = await peerOutcomeRef.get();
+
+      if (peerDoc.exists) {
+        const { outcome } = peerDoc.data();
+        console.log('Fetched Peer Outcome:', outcome);
+        return outcome; // 데이터 반환
+      } else {
+        console.log('No data found for peer outcome.');
+        return 0; // 데이터가 없으면 0 반환
+      }
+    } catch (error) {
+      console.error('Error fetching peer outcome:', error);
+      return 0; // 오류 발생 시 기본값 0 반환
+    }
+  };
 
   // 확인 버튼 클릭 시
-  const handleConfirmClick = () => {
+  const handleConfirmClick = async () => {
     if (!selectedDate) {
       Alert.alert('입력 오류', '연도와 월을 선택하세요.');
       return;
     }
 
     if (!validateAge(age)) {
-     Alert.alert('입력 오류', '나이를 올바르게 입력하세요.');
-     return;
-   }
-
-    setChartData(fetchChartData());
-    setSummaryData(fetchSummaryData());
-    setIsConfirmed(true); // 데이터 확인 상태로 변경
-
-    console.log("연령대별 지출 비교 선택 날짜: "+selectedDate);
-    console.log("연령대별 지출 비교 내 나이: "+age);
-  };
-
-  // 캘린더에서 날짜 선택 완료 시
-  const handleConfirmDate = (event, date) => {
-    if (date) {
-      setSelectedDate(date); // 선택된 날짜 저장
+      Alert.alert('입력 오류', '나이를 올바르게 입력하세요.');
+      return;
     }
-    setCalendarVisible(false); // 캘린더 닫기
+
+    try {
+      const chartData = await fetchChartData(uid);
+      setChartData(chartData); // 주차별 차트 데이터 설정
+
+      const totalOutcome = chartData.reduce((total, week) => total + week.expense, 0); // 내 지출 설정
+      setMyOutcome(totalOutcome);
+
+      const peerOutcome = await fetchPeerOutcome(age);
+      setPeerOutcome(peerOutcome);
+
+      setIsConfirmed(true); // 데이터 확인 상태로 변경
+    } catch (error) {
+      Alert.alert('오류 발생', '데이터를 불러오는 중 문제가 발생했습니다.');
+    }
   };
 
   return (
@@ -107,17 +193,17 @@ const AgeCompare = () => {
               <WeeklyChart chartData={chartData} space={20} />
             </View>
             <AmountDetail
-              income={summaryData.myExpense}
-              outcome={summaryData.peerExpense}
+              income={myOutcome}
+              outcome={peerOutcome}
               isAgeCompare={true} // AgeCompare 페이지에서 사용
               incomeLabel="내 지출"
               outcomeLabel="또래 지출"
             />
             <Text style={styles.note}>
               {`${formatDate(selectedDate)}은 또래보다 ${Math.abs(
-                summaryData.myExpense - summaryData.peerExpense
+                myOutcome - peerOutcome
               ).toLocaleString()}원 ${
-                summaryData.myExpense > summaryData.peerExpense ? '더 사용했어요' : '덜 사용했어요'
+                myOutcome > peerOutcome ? '더 사용했어요' : '덜 사용했어요'
               }`}
             </Text>
           </>

--- a/src/screens/AgeCompare.js
+++ b/src/screens/AgeCompare.js
@@ -111,7 +111,7 @@ const AgeCompare = () => {
               outcome={summaryData.peerExpense}
               isAgeCompare={true} // AgeCompare 페이지에서 사용
               incomeLabel="내 지출"
-              expenseLabel="또래 지출"
+              outcomeLabel="또래 지출"
             />
             <Text style={styles.note}>
               {`${formatDate(selectedDate)}은 또래보다 ${Math.abs(

--- a/src/screens/AgeCompare.js
+++ b/src/screens/AgeCompare.js
@@ -108,7 +108,7 @@ const AgeCompare = () => {
             </View>
             <AmountDetail
               income={summaryData.myExpense}
-              expense={summaryData.peerExpense}
+              outcome={summaryData.peerExpense}
               isAgeCompare={true} // AgeCompare 페이지에서 사용
               incomeLabel="내 지출"
               expenseLabel="또래 지출"

--- a/src/screens/MenuBar.js
+++ b/src/screens/MenuBar.js
@@ -15,7 +15,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import styles from '../styles/common/menuBarStyles.js';
 
-const MenuBar = () => {
+ const MenuBar = ({ route }) => {
+  const { userName, percent } = route.params; // 매개변수 접근
   const navigation = useNavigation(); // navigation 객체 가져오기
 
   const handleMenuClick = (route) => {
@@ -28,15 +29,16 @@ const MenuBar = () => {
       {/* 메뉴 외부 클릭 시 닫힘 */}
       <View style={styles.overlay}>
         <TouchableWithoutFeedback>
-
           {/* 메뉴 내부 클릭 방지 */}
           <View style={styles.menuContainer}>
 
             {/* 상단 사용자 정보 */}
             <View style={styles.header}>
               <FontAwesomeIcon icon={faUsers} size={40} color="#fff" style={styles.icon} />
-              <Text style={styles.userText}>안녕하세요. ○○님</Text>
-              <Text style={styles.userSubText}>이번 달 목표 금액의 10%를 사용하셨어요</Text>
+              <Text style={styles.userText}>안녕하세요. {userName}님</Text>
+              <Text style={styles.userSubText}>
+                이번 달 목표 금액의 {percent}%를 사용하셨어요
+              </Text>
             </View>
 
             {/* 메뉴 아이템 목록 */}

--- a/src/screens/MenuBar.js
+++ b/src/screens/MenuBar.js
@@ -28,8 +28,10 @@ const MenuBar = () => {
       {/* 메뉴 외부 클릭 시 닫힘 */}
       <View style={styles.overlay}>
         <TouchableWithoutFeedback>
+
           {/* 메뉴 내부 클릭 방지 */}
           <View style={styles.menuContainer}>
+
             {/* 상단 사용자 정보 */}
             <View style={styles.header}>
               <FontAwesomeIcon icon={faUsers} size={40} color="#fff" style={styles.icon} />
@@ -39,26 +41,32 @@ const MenuBar = () => {
 
             {/* 메뉴 아이템 목록 */}
             <View style={styles.menuList}>
+
               <TouchableOpacity style={styles.menuItem} onPress={() => handleMenuClick('Calendar')}>
                 <FontAwesomeIcon icon={faCalendarAlt} size={24} color="#fff" />
                 <Text style={styles.menuText}>캘린더</Text>
               </TouchableOpacity>
+
               <TouchableOpacity style={styles.menuItem} onPress={() => handleMenuClick('MonthlyStatics')}>
                 <FontAwesomeIcon icon={faChartBar} size={24} color="#fff" />
                 <Text style={styles.menuText}>나의 월별 통계</Text>
               </TouchableOpacity>
+
               <TouchableOpacity style={styles.menuItem} onPress={() => handleMenuClick('AgeCompare')}>
                 <FontAwesomeIcon icon={faUsers} size={24} color="#fff" />
                 <Text style={styles.menuText}>연령대별 지출 비교</Text>
               </TouchableOpacity>
+
               <TouchableOpacity style={styles.menuItem} onPress={() => handleMenuClick('BudgetSettings')}>
                 <FontAwesomeIcon icon={faWallet} size={24} color="#fff" />
                 <Text style={styles.menuText}>이번 달 예산 설정</Text>
               </TouchableOpacity>
+
               <TouchableOpacity style={styles.menuItem} onPress={() => handleMenuClick('CategoryCheck')}>
                 <FontAwesomeIcon icon={faThList} size={24} color="#fff" />
                 <Text style={styles.menuText}>카테고리별 확인</Text>
               </TouchableOpacity>
+
             </View>
 
             {/* 하단 로그아웃 */}

--- a/src/screens/MonthlyStatics.js
+++ b/src/screens/MonthlyStatics.js
@@ -1,46 +1,211 @@
 // src/screens/MonthlyStatics.js
 // 월별 통계 페이지
 
-import React from 'react';
-import { View, FlatList } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, FlatList, ActivityIndicator } from 'react-native';
 import AmountSummary from '../components/monthlyStatics/AmountSummary';
 import Header from '../components/common/Header';
 import BudgetIndicator from '../components/monthlyStatics/BudgetIndicator';
 import MonthlyChart from '../components/common/CustomChart';
 import AmountDetail from '../components/common/AmountDetail';
 import LineIcon from '../asset/MonthlyStaticsLine.svg';
+import firestore from '@react-native-firebase/firestore'; // Firestore 연동
 import styles from '../styles/monthlyStatics/monthlyStaticsStyles';
+import { useMonthlyStatics } from '../context/MonthlyStaticsContext'; // Context 사용
 
 const MonthlyStatics = () => {
-  const chartData = [
-    { label: '1월', income: 12000, expense: 8000 },
-    { label: '2월', income: 4000, expense: 7000 },
-    { label: '3월', income: 8000, expense: 1000 },
-    { label: '4월', income: 10000, expense: 5000 },
-    { label: '5월', income: 15000, expense: 12000 },
-    { label: '6월', income: 2000, expense: 500 },
-    { label: '7월', income: 12000, expense: 8000 },
-    { label: '8월', income: 4000, expense: 7000 },
-    { label: '9월', income: 8000, expense: 1000 },
-    { label: '10월', income: 10000, expense: 5000 },
-    { label: '11월', income: 15000, expense: 12000 },
-    { label: '12월', income: 2000, expense: 500 },
-  ];
+  const uid = "2"; // 테스트 uid
 
+  const { cachedData, setCachedData } = useMonthlyStatics(); // 컨텍스트 사용
+  const [loading, setLoading] = useState(true);
+
+  const [income, setIncome] = useState(cachedData.income); // 이번달 수입
+  const [outcome, setOutcome] = useState(cachedData.outcome); // 이번달 지출
+  const [budget, setBudget] = useState(cachedData.budget); // 이번달 예산
+  const [lastMonthIncome, setLastMonthIncome] = useState(cachedData.lastMonthIncome); // 지난달 수입
+  const [lastMonthOutcome, setLastMonthOutcome] = useState(cachedData.lastMonthOutcome); // 지난달 예산
+  const [chartData, setChartData] = useState(cachedData.chartData); // 월별 차트 데이터
+  const [incomeList, setIncomeList] = useState(cachedData.incomeList); // 수입 상세 리스트
+  const [outcomeList, setOutcomeList] = useState(cachedData.outcomeList); // 지출 상세 리스트
+
+  // Firebase에서 월별 데이터를 가져오는 함수
+  const fetchMonthlyData = async () => {
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+
+    const newChartData = [];
+    const newIncomeList = [];
+    const newOutcomeList = [];
+
+    let currentMonthIncome = 0;
+    let currentMonthOutcome = 0;
+    let lastMonthIncome = 0;
+    let lastMonthOutcome = 0;
+
+    try {
+      const userRef = firestore().collection('Users').doc(uid);
+
+      for (let month = 1; month <= currentMonth; month++) {
+        const monthPrefix = `${currentYear}-${String(month).padStart(2, '0')}`;
+        const possibleDates = Array.from({ length: 31 }, (_, i) =>
+          `${monthPrefix}-${String(i + 1).padStart(2, '0')}`
+        );
+
+        let monthlyIncome = 0;
+        let monthlyOutcome = 0;
+
+        for (const date of possibleDates) {
+          // 공통적으로 수입 또는 지출 데이터를 처리하는 함수
+          const processDoc = async (docType, list, updateMonthlySum) => {
+            const doc = await userRef.collection(date).doc(docType).get();
+            if (doc.exists) {
+              const data = doc.data();
+              const amount = data.money || 0;
+
+              // 월별 수입/지출 총합 업데이트
+              updateMonthlySum(amount);
+
+              // 리스트에 추가
+              list.push({
+                id: doc.id, // Firestore 문서의 고유 ID
+                memo: data.memo || '',
+                money: amount,
+                date: date,
+                time: data.time || '',
+                category: data.category || '',
+              });
+            }
+          };
+
+          // 병렬로 수입 및 지출 데이터를 처리
+          await Promise.all([
+            processDoc('income', newIncomeList, (amount) => (monthlyIncome += amount)),
+            processDoc('outcome', newOutcomeList, (amount) => (monthlyOutcome += amount)),
+          ]);
+        }
+
+        newChartData.push({
+          label: `${month}월`,
+          income: monthlyIncome,
+          expense: monthlyOutcome,
+        });
+
+        if (month === currentMonth) {
+          currentMonthIncome = monthlyIncome;
+          currentMonthOutcome = monthlyOutcome;
+        }
+
+        // 지난달 데이터 저장
+         const isLastMonth =
+           currentMonth === 1
+             ? month === 12 && currentYear - 1 === currentYear
+             : month === currentMonth - 1;
+
+         if (isLastMonth) {
+           lastMonthIncome = monthlyIncome;
+           lastMonthOutcome = monthlyOutcome;
+         }
+      }
+
+      setIncome(currentMonthIncome);
+      setOutcome(currentMonthOutcome);
+      setLastMonthIncome(lastMonthIncome);
+      setLastMonthOutcome(lastMonthOutcome);
+      setChartData(newChartData);
+
+      setIncomeList(newIncomeList);
+      setOutcomeList(newOutcomeList);
+
+      setCachedData((prev) => ({
+        ...prev,
+        income: currentMonthIncome,
+        outcome: currentMonthOutcome,
+        lastMonthIncome: lastMonthIncome,
+        lastMonthOutcome: lastMonthOutcome,
+        chartData: newChartData,
+        incomeList: newIncomeList,
+        outcomeList: newOutcomeList,
+      }));
+    } catch (error) {
+      console.error('Error fetching monthly data:', error);
+    }
+  };
+
+
+  // 이번 달 예산 가져오기
+  const fetchMonthlyBudget = async () => {
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = String(now.getMonth() + 1).padStart(2, '0');
+    const targetPrefix = `${currentYear}-${currentMonth}`;
+
+    try {
+      const userRef = firestore().collection('Users').doc(uid);
+      const budgetDoc = await userRef.collection('budget').doc(targetPrefix).get();
+      if (budgetDoc.exists) {
+        const fetchedBudget = budgetDoc.data().targetBudget;
+        setBudget(fetchedBudget);
+
+        setCachedData((prev) => ({
+          ...prev,
+          budget: fetchedBudget,
+        }));
+
+        console.log(`이번달 예산: ${budget}`);
+      }
+    } catch (error) {
+      console.error('Error fetching budget data:', error);
+    }
+  };
+
+  // 데이터 로드 및 캐싱 확인
+  useEffect(() => {
+    if (!cachedData.chartData.length) {
+      const fetchData = async () => {
+        setLoading(true);
+        await fetchMonthlyData();
+        await fetchMonthlyBudget();
+        setLoading(false);
+      };
+
+      console.log("파이어베이스에서 월별 통계 데이터 조회");
+
+      fetchData();
+    } else {
+      setBudget(cachedData.budget);
+      setIncome(cachedData.income);
+      setOutcome(cachedData.outcome);
+      setLastMonthIncome(cachedData.lastMonthIncome);
+      setLastMonthOutcome(cachedData.lastMonthOutcome);
+      setChartData(cachedData.chartData);
+      setIncomeList(cachedData.incomeList);
+      setOutcomeList(cachedData.outcomeList);
+      setLoading(false);
+
+      console.log("context에서 월별 통계 데이터 조회");
+      console.log(incomeList);
+      console.log(outcomeList);
+      console.log(`지난달 수입: ${lastMonthIncome}`);
+      console.log(`지난달 지출: ${lastMonthOutcome}`);
+    }
+  }, [cachedData]);
+
+  // 섹션 데이터
   const sections = [
     {
       key: 'summary',
       component: (
         <View style={styles.summaryContainer}>
-          <AmountSummary label="총 잔액" amount={2500000} isIncome={true} />
+          <AmountSummary label="총 잔액" isBudget={true} budget={budget} outcome={outcome} />
           <LineIcon height={47} style={styles.lineIcon} />
-          <AmountSummary label="총 지출" amount={5000} isIncome={false} />
+          <AmountSummary label="총 지출" isBudget={false} budget={budget} outcome={outcome} />
         </View>
       ),
     },
     {
       key: 'budget',
-      component: <BudgetIndicator percentage={30} totalAmount={300000} />,
+      component: <BudgetIndicator budget={budget} outcome={outcome} />,
     },
     {
       key: 'chart',
@@ -48,19 +213,29 @@ const MonthlyStatics = () => {
         <View style={styles.roundedContainer}>
           <MonthlyChart chartData={chartData} />
           <AmountDetail
-            income={1600000}
-            incomeChange={10000}
-            expense={50000}
-            expenseChange={60000}
+            income={income}
+            incomeChange={income - lastMonthIncome}
+            outcome={outcome}
+            outcomeChange={outcome - lastMonthOutcome}
+            incomeList={incomeList}
+            outcomeList={outcomeList}
           />
         </View>
       ),
     },
   ];
 
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color="#0000ff" marginTop="30" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Header title="나의 월별 통계" /> {/* Header 수정 */}
+      <Header title="나의 월별 통계" />
       <FlatList
         data={sections}
         keyExtractor={(item) => item.key}

--- a/src/screens/MonthlyStatics.js
+++ b/src/screens/MonthlyStatics.js
@@ -11,127 +11,129 @@ import AmountDetail from '../components/common/AmountDetail';
 import LineIcon from '../asset/MonthlyStaticsLine.svg';
 import firestore from '@react-native-firebase/firestore'; // Firestore 연동
 import styles from '../styles/monthlyStatics/monthlyStaticsStyles';
-import { useMonthlyStatics } from '../context/MonthlyStaticsContext'; // Context 사용
 
 const MonthlyStatics = () => {
   const uid = "2"; // 테스트 uid
 
-  const { cachedData, setCachedData } = useMonthlyStatics(); // 컨텍스트 사용
   const [loading, setLoading] = useState(true);
-
-  const [income, setIncome] = useState(cachedData.income); // 이번달 수입
-  const [outcome, setOutcome] = useState(cachedData.outcome); // 이번달 지출
-  const [budget, setBudget] = useState(cachedData.budget); // 이번달 예산
-  const [lastMonthIncome, setLastMonthIncome] = useState(cachedData.lastMonthIncome); // 지난달 수입
-  const [lastMonthOutcome, setLastMonthOutcome] = useState(cachedData.lastMonthOutcome); // 지난달 예산
-  const [chartData, setChartData] = useState(cachedData.chartData); // 월별 차트 데이터
-  const [incomeList, setIncomeList] = useState(cachedData.incomeList); // 수입 상세 리스트
-  const [outcomeList, setOutcomeList] = useState(cachedData.outcomeList); // 지출 상세 리스트
+  const [income, setIncome] = useState(0); // 이번달 수입
+  const [outcome, setOutcome] = useState(0); // 이번달 지출
+  const [budget, setBudget] = useState(0); // 이번달 예산
+  const [lastMonthIncome, setLastMonthIncome] = useState(0); // 지난달 수입
+  const [lastMonthOutcome, setLastMonthOutcome] = useState(0); // 지난달 지출
+  const [chartData, setChartData] = useState([]); // 월별 차트 데이터
+  const [incomeList, setIncomeList] = useState([]); // 수입 상세 리스트
+  const [outcomeList, setOutcomeList] = useState([]); // 지출 상세 리스트
 
   // Firebase에서 월별 데이터를 가져오는 함수
   const fetchMonthlyData = async () => {
     const now = new Date();
     const currentYear = now.getFullYear();
-    const currentMonth = now.getMonth() + 1;
+    const currentMonth = now.getMonth() + 1; // 현재 월
+    const previousMonth = currentMonth === 1 ? 12 : currentMonth - 1; // 지난달
+    const previousMonthYear = currentMonth === 1 ? currentYear - 1 : currentYear; // 지난달 연도
 
     const newChartData = [];
     const newIncomeList = [];
     const newOutcomeList = [];
 
-    let currentMonthIncome = 0;
-    let currentMonthOutcome = 0;
-    let lastMonthIncome = 0;
-    let lastMonthOutcome = 0;
+    let totalIncome = 0; // 현재 달 총 수입
+    let totalOutcome = 0; // 현재 달 총 지출
+    let lastMonthIncomeTotal = 0; // 지난달 총 수입
+    let lastMonthOutcomeTotal = 0; // 지난달 총 지출
 
     try {
       const userRef = firestore().collection('Users').doc(uid);
 
-      for (let month = 1; month <= currentMonth; month++) {
-        const monthPrefix = `${currentYear}-${String(month).padStart(2, '0')}`;
-        const possibleDates = Array.from({ length: 31 }, (_, i) =>
-          `${monthPrefix}-${String(i + 1).padStart(2, '0')}`
-        );
-
-        let monthlyIncome = 0;
-        let monthlyOutcome = 0;
-
-        for (const date of possibleDates) {
-          // 공통적으로 수입 또는 지출 데이터를 처리하는 함수
-          const processDoc = async (docType, list, updateMonthlySum) => {
-            const doc = await userRef.collection(date).doc(docType).get();
-            if (doc.exists) {
-              const data = doc.data();
-              const amount = data.money || 0;
-
-              // 월별 수입/지출 총합 업데이트
-              updateMonthlySum(amount);
-
-              // 리스트에 추가
-              list.push({
-                id: doc.id, // Firestore 문서의 고유 ID
-                memo: data.memo || '',
-                money: amount,
-                date: date,
-                time: data.time || '',
-                category: data.category || '',
-              });
-            }
-          };
-
-          // 병렬로 수입 및 지출 데이터를 처리
-          await Promise.all([
-            processDoc('income', newIncomeList, (amount) => (monthlyIncome += amount)),
-            processDoc('outcome', newOutcomeList, (amount) => (monthlyOutcome += amount)),
-          ]);
-        }
-
-        newChartData.push({
-          label: `${month}월`,
-          income: monthlyIncome,
-          expense: monthlyOutcome,
-        });
-
-        if (month === currentMonth) {
-          currentMonthIncome = monthlyIncome;
-          currentMonthOutcome = monthlyOutcome;
-        }
-
-        // 지난달 데이터 저장
-         const isLastMonth =
-           currentMonth === 1
-             ? month === 12 && currentYear - 1 === currentYear
-             : month === currentMonth - 1;
-
-         if (isLastMonth) {
-           lastMonthIncome = monthlyIncome;
-           lastMonthOutcome = monthlyOutcome;
-         }
+      // Firebase에서 availableDates 필드 가져오기
+      const userSnapshot = await userRef.get();
+      if (!userSnapshot.exists) {
+        console.error("User data not found.");
+        return;
       }
 
-      setIncome(currentMonthIncome);
-      setOutcome(currentMonthOutcome);
-      setLastMonthIncome(lastMonthIncome);
-      setLastMonthOutcome(lastMonthOutcome);
+      const { availableDates } = userSnapshot.data();
+      if (!availableDates || !Array.isArray(availableDates)) {
+        console.error("No available dates found.");
+        return;
+      }
+
+      // 1월부터 현재 월까지 데이터를 처리
+      const months = Array.from({ length: currentMonth }, (_, i) => i + 1);
+
+      await Promise.all(
+        months.map(async (month) => {
+          const monthPrefix = `${currentYear}-${String(month).padStart(2, '0')}`;
+          const monthlyDates = availableDates.filter((date) => date.startsWith(monthPrefix));
+
+          let monthlyIncome = 0;
+          let monthlyOutcome = 0;
+
+          await Promise.all(
+            monthlyDates.map(async (date) => {
+              const processDoc = async (docType, list, updateMonthlySum) => {
+                const doc = await userRef.collection(date).doc(docType).get();
+                if (doc.exists) {
+                  const data = doc.data();
+                  const amount = data.money || 0;
+
+                  // 월별 수입/지출 총합 업데이트
+                  updateMonthlySum(amount);
+
+                  // 리스트에 추가
+                  list.push({
+                    id: doc.id,
+                    memo: data.memo || '',
+                    money: amount,
+                    date: date,
+                    time: data.time || '',
+                    category: data.category || '',
+                  });
+                }
+              };
+
+              // 수입/지출 데이터를 각각 리스트에 추가
+              await Promise.all([
+                processDoc('income', newIncomeList, (amount) => (monthlyIncome += amount)),
+                processDoc('outcome', newOutcomeList, (amount) => (monthlyOutcome += amount)),
+              ]);
+            })
+          );
+
+          // 현재 달이면 상태 업데이트
+          if (month === currentMonth) {
+            setIncome(monthlyIncome);
+            setOutcome(monthlyOutcome);
+            setIncomeList([...newIncomeList]); // 현재 달 수입 리스트 업데이트
+            setOutcomeList([...newOutcomeList]); // 현재 달 지출 리스트 업데이트
+            totalIncome = monthlyIncome;
+            totalOutcome = monthlyOutcome;
+          }
+
+          // 지난달이면 상태 업데이트
+          if (month === previousMonth) {
+            setLastMonthIncome(monthlyIncome);
+            setLastMonthOutcome(monthlyOutcome);
+            lastMonthIncomeTotal = monthlyIncome;
+            lastMonthOutcomeTotal = monthlyOutcome;
+          }
+
+          // 차트 데이터 추가
+          newChartData.push({
+            label: `${month}월`,
+            income: monthlyIncome,
+            expense: monthlyOutcome,
+          });
+        })
+      );
+
+      // 상태 업데이트 (차트 데이터만 저장)
       setChartData(newChartData);
 
-      setIncomeList(newIncomeList);
-      setOutcomeList(newOutcomeList);
-
-      setCachedData((prev) => ({
-        ...prev,
-        income: currentMonthIncome,
-        outcome: currentMonthOutcome,
-        lastMonthIncome: lastMonthIncome,
-        lastMonthOutcome: lastMonthOutcome,
-        chartData: newChartData,
-        incomeList: newIncomeList,
-        outcomeList: newOutcomeList,
-      }));
     } catch (error) {
       console.error('Error fetching monthly data:', error);
     }
   };
-
 
   // 이번 달 예산 가져오기
   const fetchMonthlyBudget = async () => {
@@ -146,12 +148,6 @@ const MonthlyStatics = () => {
       if (budgetDoc.exists) {
         const fetchedBudget = budgetDoc.data().targetBudget;
         setBudget(fetchedBudget);
-
-        setCachedData((prev) => ({
-          ...prev,
-          budget: fetchedBudget,
-        }));
-
         console.log(`이번달 예산: ${budget}`);
       }
     } catch (error) {
@@ -159,37 +155,21 @@ const MonthlyStatics = () => {
     }
   };
 
-  // 데이터 로드 및 캐싱 확인
+  // 데이터 로드
+  // 일단 화면 전환되면 다시 파이어베이스에서 조회하지 않도록
   useEffect(() => {
-    if (!cachedData.chartData.length) {
-      const fetchData = async () => {
-        setLoading(true);
-        await fetchMonthlyData();
-        await fetchMonthlyBudget();
-        setLoading(false);
-      };
-
-      console.log("파이어베이스에서 월별 통계 데이터 조회");
-
-      fetchData();
-    } else {
-      setBudget(cachedData.budget);
-      setIncome(cachedData.income);
-      setOutcome(cachedData.outcome);
-      setLastMonthIncome(cachedData.lastMonthIncome);
-      setLastMonthOutcome(cachedData.lastMonthOutcome);
-      setChartData(cachedData.chartData);
-      setIncomeList(cachedData.incomeList);
-      setOutcomeList(cachedData.outcomeList);
+    const fetchData = async () => {
+      setLoading(true);
+      await fetchMonthlyData();
+      await fetchMonthlyBudget();
       setLoading(false);
+    };
 
-      console.log("context에서 월별 통계 데이터 조회");
-      console.log(incomeList);
-      console.log(outcomeList);
-      console.log(`지난달 수입: ${lastMonthIncome}`);
-      console.log(`지난달 지출: ${lastMonthOutcome}`);
-    }
-  }, [cachedData]);
+    console.log(incomeList);
+    console.log(outcomeList);
+
+    fetchData();
+  }, []);
 
   // 섹션 데이터
   const sections = [

--- a/src/screens/MonthlyStatics.js
+++ b/src/screens/MonthlyStatics.js
@@ -215,15 +215,18 @@ const MonthlyStatics = () => {
 
   return (
     <View style={styles.container}>
-      <Header title="나의 월별 통계" />
       <FlatList
         data={sections}
         keyExtractor={(item) => item.key}
         renderItem={({ item }) => item.component}
         contentContainerStyle={styles.container}
+        ListHeaderComponent={
+          <Header title="나의 월별 통계" />
+        }
       />
     </View>
   );
+
 };
 
 export default MonthlyStatics;

--- a/src/styles/common/headerStyles.js
+++ b/src/styles/common/headerStyles.js
@@ -17,7 +17,9 @@ export default StyleSheet.create({
     alignItems: 'center', // 아이콘 수평 중앙 정렬
   },
   headerTitle: {
-    marginRight: 13,
+    justifyContent: 'center', // 아이콘 수직 중앙 정렬
+    alignItems: 'center', // 아이콘 수평 중앙 정렬
+    marginRight: 37,
     flex: 1, // 제목을 중앙에 위치하도록 설정
     fontSize: 18, // 텍스트 크기
     fontWeight: 'bold', // 굵은 글씨

--- a/src/styles/common/menuBarStyles.js
+++ b/src/styles/common/menuBarStyles.js
@@ -14,7 +14,7 @@ export default StyleSheet.create({
     flex: 1,
     backgroundColor: '#276749',
     width: '78%',
-    paddingVertical: 20,
+    paddingVertical: 40,
     paddingHorizontal: 15,
     borderTopRightRadius: 20,
     borderBottomRightRadius: 20,
@@ -44,7 +44,7 @@ export default StyleSheet.create({
   menuItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 12,
+    paddingVertical: 20,
     borderBottomWidth: 1,
     borderBottomColor: '#fff',
     marginBottom: 10,

--- a/src/styles/monthlyStatics/incomeOutcomeListStyles.js
+++ b/src/styles/monthlyStatics/incomeOutcomeListStyles.js
@@ -1,4 +1,4 @@
-// src/styles/monthlyStatics/incomeExpenseListStyles.js
+// src/styles/monthlyStatics/incomeOutcomeListStyles.js
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({


### PR DESCRIPTION
## 월별 통계 페이지 
- Firebase에서 유저의 현재 연도의 1월부터 현재 월까지의 수입 및 지출 데이터를 조회하는 데 시간이 오래 걸리는 문제를 해결하기 위해 Users 컬렉션에 **availableDates** 필드(형식: yyyy-mm-dd, 배열 형태)를 추가
- **availableDates**는 **월별 데이터를 보유한 날짜**를 배열로 관리

## 연령대별 지출 비교 페이지 
- 마찬가지로 데이터 조회 시 시간이 오래 걸리는 문제를 해결하기 위해 **WeekAmount** 컬렉션을 생성하여, 현재 **월의 주차별 데이터**를 조회
- 또래 지출 비교를 위해 **PeerOutcome** 컬렉션을 별도로 생성하여, **동일 연령대의 지출 데이터**를 관리